### PR TITLE
Add API functions iof:forward_mod_with_push_vlan/{4,5} to icontrol app

### DIFF
--- a/icontrol/README.md
+++ b/icontrol/README.md
@@ -305,6 +305,11 @@ Create a flow in table 0 on the switch associated with Key, or the
 default switch if Key is not given, forwarding traffic from the
 InPort to the OutPort at the Priority.
 
+### iof:forward_mod_with_push_vlan(Key, Priority, InPort, OutPort, VlanID)
+
+Create the same flow as with `iof:forward_mod/4` but add a VLAN tag
+with VlanID to an outgoing packet.
+
 ### iof:bridge(Key, Priority, Port1, Port2)
 
 Create flows in table 0 on the switch associated with Key, or the


### PR DESCRIPTION
These functions allow to crate a flow that forward packets between the
ports and add VLAN tag to packets on output.
