### PR TITLE
IP address white and black lists

### DIFF
--- a/tapestry/README.md
+++ b/tapestry/README.md
@@ -201,6 +201,11 @@ tapestry | clean_interval | [{days,0},{hms,{1,0,0}}] | interval between purging 
 tapestry | data_max_age | [{days,2},{hms,{0,0,0}}] | purge data older than data_max_age
 tapestry | use_graphviz | false | EXPERIMENTAL: use graphviz to calculate the location of the community dots in community graphs
 tapestry | neato_bin | "user/local/bin/neato" | path to neato from graphviz installation
+tapestry | community_detector | part_louvain | module to use for community detector (only set in sys.config)
+tapestry | requester_whitelist | [{"10.0.0.0",8}] | include these ip addresses as requesters
+tapestry | requester_blacklist | [{"192.168.0.0",16}] | exclude these ip addresses as requesters
+tapestry | resolved_whitelist | [{"::",0}] | include these ip addresses as resolved responses
+tapestry | resolved_blacklist | [{"10.13.11.24",32}] | exclude these ip addresses as reolved responses
 of_driver | listen_ip | {0,0,0,0} | open flow controller listener IP address
 of_driver | listen_port | 6653 | open flow controller listener port
 
@@ -209,6 +214,8 @@ not allowed.  test_ui should not be used with any other datasource and
 anonymized and logfile may not be used together.
 
 neato_bin must be the path to the neato binary from the graphviz installation.  This is only used if use_graphviz is true.
+
+Only requester, resolved address pairs that are included int he requester_whitelist and resolved_whitelist and not excluded by the requester_blacklist and resolved_blacklist are included in the data considered by tapestry's community detection and NCI calculation.  An address in these lists is specified as with a ipv4 or ipv6 address (as a string) and the number of bits that much match exactly.  For example, to match all 10.x.x.x networks, use {"10.0.0.0",8}.  To match 10.12.22.44 exactly, use {"10.12.22.44",32}.
 
 datasource|Description
 ----------------|-----------

--- a/tapestry/apps/tapestry/test/tap_batch_test.erl
+++ b/tapestry/apps/tapestry/test/tap_batch_test.erl
@@ -47,7 +47,7 @@ parse_logfile() ->
 29-Oct-2014 09:48:02.588 client 2620:10a:6000:2000::2c6#7908: UDP: query: daisy.ubuntu.com IN A response: NOERROR + daisy.ubuntu.com.  339 IN A 91.189.92.55; daisy.ubuntu.com. 339 IN A 91.189.92.57;
 29-Oct-2014 09:48:06.309 client 2620:10a:6000:2000::28c#23959: UDP: query: outlook.infoblox.com IN A response: NOERROR +A outlook.infoblox.com. 10 IN CNAME casarray1.infoblox.com.; casarray1.infoblox.com. 10 IN A 10.120.3.104;
 ">>,
-    R = tap_batch:parse_logfile(Bin),
+    R = tap_batch:parse_logfile(Bin, fun(_,_) -> true end),
     ?assertMatch(
         [{{{192,168,11,172},_},{{17,151,226,32},_}},
          {{{192,168,11,130},_},{{8193,1048,5162,404,0,0,0,3191},_}},

--- a/tapestry/apps/tapestry/test/tap_dns_test.erl
+++ b/tapestry/apps/tapestry/test/tap_dns_test.erl
@@ -1,0 +1,144 @@
+%%------------------------------------------------------------------------------
+%% Copyright 2014 FlowForwarding.org
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%-----------------------------------------------------------------------------
+
+%% @author Erlang Solutions Ltd. <openflow@erlang-solutions.com>
+%% @copyright 2014 FlowForwarding.org
+
+-module (tap_dns_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%------------------------------------------------------------------------------
+
+tap_data_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     [
+         {"binaryaddr", fun binaryaddr/0}
+        ,{"intaddr", fun intaddr/0}
+        ,{"mkmask", fun mkmask/0}
+        ,{"white list", fun white_list/0}
+        ,{"black list", fun black_list/0}
+        ,{"combo", fun combo/0}
+        ,{"none", fun none/0}
+     ]
+    }.
+
+setup() ->
+    ok.
+
+cleanup(ok) ->
+    ok.
+
+%%------------------------------------------------------------------------------
+
+binaryaddr() ->
+    ?assertEqual(<<1,2,3,4>>, tap_dns:binaryaddr({1,2,3,4})),
+    ?assertEqual(<<1:16,2:16,3:16,4:16,5:16,6:16,7:16,8:16>>,
+                                    tap_dns:binaryaddr({1,2,3,4,5,6,7,8})).
+
+intaddr() ->
+    ?assertEqual({32, 1 *256*256*256 +
+                      2 *256*256 +
+                      3 *256 +
+                      4}, tap_dns:intaddr(tap_dns:binaryaddr({1,2,3,4}))),
+    ?assertEqual({128, 1 *65536*65536*65536*65536*65536*65536*65536 +
+                       2 *65536*65536*65536*65536*65536*65536 +
+                       3 *65536*65536*65536*65536*65536 +
+                       4 *65536*65536*65536*65536 +
+                       5 *65536*65536*65536 +
+                       6 *65536*65536 +
+                       7 *65536 +
+                       8},
+                    tap_dns:intaddr(tap_dns:binaryaddr({1,2,3,4,5,6,7,8}))).
+
+mkmask() ->
+    ?assertEqual({{32, 255 *256*256*256}, {32, 10 *256*256*256}},
+                                            tap_dns:mkmask({10,0,0,0}, 8)),
+    ?assertEqual({{32, 255 *256*256*256 +
+                       240  *256*256},
+                  {32, 172 *256*256*256 +
+                        16 *256*256}},
+                                            tap_dns:mkmask({172,16,0,0}, 12)),
+    ?assertEqual({{128, 254*256 *65536*65536*65536*65536*65536*65536*65536},
+                  {128, 252     *65536*65536*65536*65536*65536*65536*65536}},
+                                    tap_dns:mkmask({252,0,0,0,0,0,0,0}, 7)).
+
+white_list() ->
+    % allow all private networks
+    WhiteList = [tap_dns:mkmask({10,0,0,0},8),
+                 tap_dns:mkmask({172,16,0,0},12),
+                 tap_dns:mkmask({192,168,0,0},16),
+                 tap_dns:mkmask({
+                     16#fc00,0,0,0,0,0,0,0}, 7)],
+    BlackList = [],
+    ?assertNot(tap_dns:allow({1,2,3,4}, WhiteList, BlackList)),
+    ?assertNot(tap_dns:allow({1,2,3,4,5,6,7,8}, WhiteList, BlackList)),
+    ?assert(tap_dns:allow({10,1,2,3}, WhiteList, BlackList)),
+    ?assert(tap_dns:allow({172,16,2,3}, WhiteList, BlackList)),
+    ?assert(tap_dns:allow({172,17,2,3}, WhiteList, BlackList)),
+    ?assert(tap_dns:allow({192,168,2,3}, WhiteList, BlackList)),
+    ?assert(tap_dns:allow({252 *256,2,3,4,5,6,7,8}, WhiteList, BlackList)),
+    ok.
+
+black_list() ->
+    % don't allow all private networks
+    WhiteList = [tap_dns:mkmask({0,0,0,0},0),
+                 tap_dns:mkmask({0,0,0,0,0,0,0,0},0)],
+    BlackList = [tap_dns:mkmask({10,0,0,0},8),
+                 tap_dns:mkmask({172,16,0,0},12),
+                 tap_dns:mkmask({192,168,0,0},16),
+                 tap_dns:mkmask({
+                     16#fc00,0,0,0,0,0,0,0}, 7)],
+    ?assert(tap_dns:allow({1,2,3,4}, WhiteList, BlackList)),
+    ?assert(tap_dns:allow({1,2,3,4,5,6,7,8}, WhiteList, BlackList)),
+    ?assertNot(tap_dns:allow({10,1,2,3}, WhiteList, BlackList)),
+    ?assertNot(tap_dns:allow({172,16,2,3}, WhiteList, BlackList)),
+    ?assertNot(tap_dns:allow({172,17,2,3}, WhiteList, BlackList)),
+    ?assertNot(tap_dns:allow({192,168,2,3}, WhiteList, BlackList)),
+    ?assertNot(tap_dns:allow({252 *256,2,3,4,5,6,7,8}, WhiteList, BlackList)),
+    ok.
+
+combo() ->
+    % allow 10.0.0.0 private networks
+    WhiteList = [tap_dns:mkmask({10,0,0,0},8)],
+    % do not allow 10.11.12.13
+    BlackList = [tap_dns:mkmask({10,11,12,13},32)],
+    ?assertNot(tap_dns:allow({1,2,3,4}, WhiteList, BlackList)),
+    ?assertNot(tap_dns:allow({1,2,3,4,5,6,7,8}, WhiteList, BlackList)),
+    ?assert(tap_dns:allow({10,1,2,3}, WhiteList, BlackList)),
+    ?assertNot(tap_dns:allow({10,11,12,13}, WhiteList, BlackList)),
+    ok.
+
+none() ->
+    WhiteList = [tap_dns:mkmask({0,0,0,0},0),
+                 tap_dns:mkmask({0,0,0,0,0,0,0,0},0)],
+    BlackList = [],
+    ?assert(tap_dns:allow({1,2,3,4}, WhiteList, BlackList)),
+    ?assert(tap_dns:allow({1,2,3,4,5,6,7,8}, WhiteList, BlackList)).
+
+%-------------------------------------------------------------------------------
+% helpers
+%-------------------------------------------------------------------------------
+
+trace() ->
+    dbg:start(),
+    dbg:tracer(),
+    dbg:p(all, c),
+    dbg:tpl(tap_dns, mkmask, [{'_',[],[{return_trace}]}]),
+    dbg:tpl(tap_dns, mask, [{'_',[],[{return_trace}]}]).
+

--- a/tapestry/rel/files/sys.config
+++ b/tapestry/rel/files/sys.config
@@ -24,9 +24,19 @@
              {max_communities, infinity},
              {comm_size_limit, infinity},
              {nci_calc_time_limit_sec, 300},
+             % community_detector selects the algorithm to use to
+             % select communities.  Must be set in sys.config.
+             % part_labelprop - label propogation
+             % part_louvain - Louvain community detection
              {community_detector, part_louvain},
              {neato_bin, "/usr/local/bin/neato"},
-             {use_graphviz, false}
+             {use_graphviz, false},
+             % capture all requester ip addresses
+             {requester_whitelist,[{"0.0.0.0",0},{"::",0}]},
+             {requester_blacklist,[]},
+             % accept all resolved ip addresses
+             {resolved_whitelist,[{"0.0.0.0",0},{"::",0}]},
+             {resolved_blacklist,[]}
  ]},
  {of_driver, [
               {listen, false},

--- a/tapestry/rel/files/tapestry.config
+++ b/tapestry/rel/files/tapestry.config
@@ -21,3 +21,9 @@
 %{connect_to, {{10,48,33,176}, 6634}}.
 %{connect_to, {{10,32,3,205}, 6634}}.
 %{connect_to, {{10,32,1,104}, 6634}}.
+
+% Only internal requesters and resolved addresses
+% {requester_whitelist,[{"10.0.0.0",8},{"172.16.0.0",12},{"192.168.0.0",16},{"fc00::",7}]}.
+% {requester_blacklist,[]}.
+% {resolved_whitelist,[{"10.0.0.0",8},{"172.16.0.0",12},{"192.168.0.0",16},{"fc00::",7}]}.
+% {resolved_blacklist,[]}.


### PR DESCRIPTION
Adds configuration parameters to specify IP addresses and address masks to include or exclude from the community detection and NCI calculation.  See README, sys.config, and tapestry.config for details.
