### PR TITLE
copy binary of the Query string to improve GC

### DIFF
--- a/tapestry/apps/tapestry/src/tap_batch.erl
+++ b/tapestry/apps/tapestry/src/tap_batch.erl
@@ -311,7 +311,7 @@ parse_logfile(Bin, FilterFn) ->
                     [{Timestamp,
                       tap_ds:endpoint(RequesterIpAddr,
                                             tap_dns:gethostbyaddr(Requester)),
-                      tap_ds:endpoint(ResolvedIpAddr, Query)} | L]
+                      tap_ds:endpoint(ResolvedIpAddr, binary:copy(Query))} | L]
             end
         end, [], Matches)).
 


### PR DESCRIPTION
Copy the Query string from the regexp match from the ftp log so that the larger ftp log binary is garbage collected more quickly.
