### PR TITLE
tapestry crash  prevents presenting nci details

### DIFF
--- a/tapestry/apps/tapestry/src/tap_client_data.erl
+++ b/tapestry/apps/tapestry/src/tap_client_data.erl
@@ -498,7 +498,7 @@ format_collectors(CollectorDict) ->
         end, 0, Collectors),
     JSON.
 
-collector({ofswitch, DatapathId, LastUpdate, IpAddr, QPS}) ->
+collector({ofswitch, DatapathId, IpAddr, LastUpdate, QPS}) ->
     [
         {<<"collector_type">>,<<"OF1.3 Switch">>},
         {<<"ip">>,endpoint(IpAddr)},


### PR DESCRIPTION
tapestry crashing when trying to present nci details:
*\* {function_clause,[{tap_time,rfc3339,[{10,48,33,198}],[{file,"src/tap_time.erl"},{line,56}]},{tap_client_data,rfc3339bin,1,[{file,"src/tap_client_data.erl"},{line,686}]},{tap_client_data,collector,1,[{file,"src/tap_client_data.erl"},{line,506}]},{tap_client_data,'-format_collectors/1-fun-1-',2,[{file,"src/tap_client_data.erl"},{line,497}]},{lists,mapfoldl,3,[{file,"lists.erl"},{line,1339}]},{tap_client_data,format_collectors,1,[{file,"src/tap_client_data.erl"},{line,494}]},{tap_client_data,json_collectors,2,[{file,"src/tap_client_data.erl"},{line,485}]},{tap_client_data,handle_cast,2,[{file,"src/tap_client_data.erl"},{line,207}]}]}

Problem is a tuple with the elements in the wrong order.  IpAddr and LastUpdate time are reversed causing code to try to interpret an IP address as a date/time stamp.
