### PR TITLE
When no communities are detected, put all nodes in the same community.

### DIFF
--- a/tapestry/apps/tapestry/src/part_louvain.erl
+++ b/tapestry/apps/tapestry/src/part_louvain.erl
@@ -226,8 +226,9 @@ partition(GD, L) ->
                     % partitioning didn't find any communitites, which
                     % probably means the graph wasn't big enough to
                     % yield anything interesting.  Return the
-                    % original graph.
-                    [graph(GD)];
+                    % original graph with all of the vertices
+                    % in the same community.
+                    [all_same_community(graph(GD))];
                 _ -> L
             end;
         false ->
@@ -536,6 +537,14 @@ community_degrees(#louvain_graphd{communitiesd = CommunitiesD,
         fun({C, AW, CW}, D) ->
             dict:update(C, fun({AS, CS}) -> {AS + AW, CS + CW} end, {AW, CW}, D)
         end, dict:new(), Weights).
+
+% put all of the vertices in the same community
+all_same_community(GD = #louvain_graph{neighbors = []}) ->
+    GD;
+all_same_community(GD =
+                    #louvain_graph{neighbors = Neighbors = [{First,_}|_]}) ->
+    Communities = [{Node, First} || {Node, _} <- Neighbors],
+    GD#louvain_graph{communities = Communities}.
 
 dict_lookup(Key, Dict) ->
     dict_lookup(Key, Dict, Key).

--- a/tapestry/apps/tapestry/test/part_louvain_test.erl
+++ b/tapestry/apps/tapestry/test/part_louvain_test.erl
@@ -55,6 +55,7 @@ tap_data_test_() ->
         ,{"partition_sample_1000", fun partition_sample_1000/0}
 %       ,{timeout, 200, {"partition_sample_10000", fun partition_sample_10000/0}}
 %       ,{timeout, 1000, {"partition_sample_100000", fun partition_sample_100000/0}}
+        ,{"findonecommunity", fun findonecommunity/0}
      ]
     }.
 
@@ -371,7 +372,7 @@ smallgraph() ->
                                             digraph:vertices(G),
                                             [digraph:edge(G, E) ||
                                                 E <- digraph:edges(G)]),
-    Communities = part_louvain:find_communities(LG),
+    _Communities = part_louvain:find_communities(LG),
     CleanupFn(LG).
 
 partition_ring_clique() ->
@@ -424,6 +425,31 @@ partition_sample_100000() ->
     CommunitiesPL = partition_sample_file("../test/sample_100000"),
     % XXX getting 14253, but data generator says 11243
     ?assertEqual(11243, length(CommunitiesPL)).
+
+%%------------------------------------------------------------------------------
+
+findonecommunity() ->
+    G = digraph:new(),
+    digraph:add_vertex(G, "a"),
+    digraph:add_vertex(G, "b"),
+    digraph:add_vertex(G, "c"),
+    digraph:add_vertex(G, "d"),
+    digraph:add_vertex(G, "e"),
+    digraph:add_vertex(G, "f"),
+    digraph_add_edge(G, "a", "b"),
+    digraph_add_edge(G, "a", "c"),
+    digraph_add_edge(G, "a", "d"),
+    digraph_add_edge(G, "a", "e"),
+    digraph_add_edge(G, "a", "f"),
+    {LG = #louvain_graph{}, CleanupFn} = part_louvain:graph(
+                                            digraph:vertices(G),
+                                            [digraph:edge(G, E) ||
+                                                E <- digraph:edges(G)]),
+    {Communities, _Graph, _CommunityGraph} = part_louvain:find_communities(LG),
+    % all nodes are in the same community
+    [{_, Community}|_] = Communities,
+    ?assert(lists:all(fun({_,C}) -> C == Community end, Communities)),
+    CleanupFn(LG).
 
 %%------------------------------------------------------------------------------
 


### PR DESCRIPTION
louvain detection may not find any communities if there are very few vertices or edges.
