### PR TITLE
Show unmatched DNS packet in debug message

### DIFF
--- a/tapestry/apps/tapestry/src/tap_loom.erl
+++ b/tapestry/apps/tapestry/src/tap_loom.erl
@@ -185,7 +185,8 @@ dns_reply(Data, DatapathId, CollectorIP) ->
 			Match = match_reply(DnsRec),
 			case Match of
 			    {error, _} ->
-                                ?DEBUG("No match dropped: ~p~n",[Match]);
+                                ?DEBUG("No match dropped: ~p, ~p~n",
+				       [Match, DnsRec]);
 			    {ok, ID, Query} ->
 				R = list_to_tuple(
                                         binary_to_list(Header1#ipv4.daddr)),


### PR DESCRIPTION
This might be useful when trying to figure out why Tapestry doesn't take DNS packets into account. Instead of just showing the reason (currently either `bad_response` or `no_a_record`), it also shows the parsed DNS packet as a tuple.