### PR TITLE
In iof, decode messages before printing them

### DIFF
--- a/icontrol/apps/icontrol/src/iof.erl
+++ b/icontrol/apps/icontrol/src/iof.erl
@@ -746,8 +746,8 @@ show(List) when is_list(List) ->
     ok;
 show({error, Reason}) ->
     io:format("error: ~p~n", [Reason]);
-show({ok, {ofp_message, _Version, _HdrType, _Xid, Body}}) ->
-    io:format("~P~n", [Body, 10000]);
+show({ok, {ofp_message, _Version, _HdrType, _Xid, _Body} = Message}) ->
+    show(of_msg_lib:decode(Message));
 show(Msg) ->
     io:format("~P~n", [Msg, 10000]).
     


### PR DESCRIPTION
Use `of_msg_lib:decode` to decode records into proplists before printing
them.  This has the advantage that the field names are readily visible.

For example, before this change, the output of `iof:flows()` looked like this:

```
{ofp_flow_stats_reply,[],
    [{ofp_flow_stats,0,8,404216000,1000,0,0,[],
         <<0,0,0,0,0,0,0,10>>,
         255,20188,
         {ofp_match,
             [{ofp_field,openflow_basic,in_port,false,<<0,0,0,1>>,undefined}]},
         [{ofp_instruction_apply_actions,2,
              [{ofp_action_output,16,2,no_buffer}]}]},
     {ofp_flow_stats,0,8,360038000,1000,0,0,[],
         <<0,0,0,0,0,0,0,10>>,
         237,18614,
         {ofp_match,
             [{ofp_field,openflow_basic,in_port,false,<<0,0,0,2>>,undefined}]},
         [{ofp_instruction_apply_actions,2,
              [{ofp_action_output,16,1,no_buffer}]}]}]}
```

With this change, the output looks like this:

```
  {flow_stats_reply,8,
      [{flags,[]},
       {flows,
           [[{table_id,0},
             {duration_sec,50758},
             {duration_nsec,927230000},
             {priority,1000},
             {idle_timeout,0},
             {hard_timeout,0},
             {flags,[]},
             {cookie,<<0,0,0,0,0,0,0,10>>},
             {packet_count,0},
             {byte_count,0},
             {match,[{in_port,<<0,0,0,2>>}]},
             {instructions,[{apply_actions,[{output,1,no_buffer}]}]}],
            [{table_id,0},
             {duration_sec,50758},
             {duration_nsec,971925000},
             {priority,1000},
             {idle_timeout,0},
             {hard_timeout,0},
             {flags,[]},
             {cookie,<<0,0,0,0,0,0,0,10>>},
             {packet_count,0},
             {byte_count,0},
             {match,[{in_port,<<0,0,0,1>>}]},
             {instructions,[{apply_actions,[{output,2,no_buffer}]}]}]]}]}
```

(the data is not identical in the two examples)